### PR TITLE
feat: Add support for git-lfs

### DIFF
--- a/.github/workflows/pages-generate-from-docs-dir.yml
+++ b/.github/workflows/pages-generate-from-docs-dir.yml
@@ -19,6 +19,11 @@ on: # yamllint disable-line rule:truthy
         required: false
         type: string
         description: "Optional but required if from2 is provided: Target directly under 'docs/' to copy into"
+      lfs-checkout:
+        required: false
+        type: boolean
+        default: false
+        description: "Optional boolean to turn on git-lfs during checkout"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 #permissions:
@@ -42,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          lfs: ${{ inputs.lfs-checkout }}
 
       - name: Generate Pages content
         run: |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Check the repository workflow `Actions`. There should be an action publishing th
   itself demonstrates how it works by the following usage. Another common combination example is
   `from1: src/main/resources/schemas` and `to1: schemas` and the `.md` file using links to
   `schemas/some-filename.xsd`.
+- If your documentation uses git-lfs, e.g. to provide PDFs or other binary files, you need to switch
+  on git-lfs during checkout using `lfs-checkout: true`.
 
 ### Example
 


### PR DESCRIPTION
Add an input variable to turn on git-lfs during checkout in case the documentation contains large files that are loaded via git-lfs.